### PR TITLE
Added generating concurrent enum map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This file documents recent notable changes to this project. The format of this
+file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Generated enum maps during parsing events. The enum value of each column starts with `1_u32`.
+
+### Changed
+
+- `Description` contains enum fields as `String` which is converted from `u32` at `describe` functions. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
 itertools = "0.8"
+log = "0.4"
 num-traits = "0.2"
 statistical = "1.0.0"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ authors = [
 edition = "2018"
 
 [dependencies]
+chashmap = "2.2"
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
 itertools = "0.8"
+log = "0.4"
 num-traits = "0.2"
 statistical = "1.0.0"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2018"
 
 [dependencies]
-chashmap = "2.2"
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
+dashmap = "1.2"
 itertools = "0.8"
 log = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
 dashmap = "1.2"
 itertools = "0.8"
-log = "0.4"
 num-traits = "0.2"
 statistical = "1.0.0"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "structured"
 version = "0.1.0"
 authors = [
     "Min Kim <msk@dolbo.net>",
+    "Min Shao <mshao@petabi.com>",
     "Sehkone Kim <sehkone@petabi.com>",
 ]
 edition = "2018"
@@ -10,8 +11,8 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
-dashmap = "1.2"
+dashmap = "1"
 itertools = "0.8"
 num-traits = "0.2"
-statistical = "1.0.0"
+statistical = "1"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
 itertools = "0.8"
-log = "0.4"
 num-traits = "0.2"
 statistical = "1.0.0"
 serde = { version = "1", features = ["derive"] }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -165,18 +165,6 @@ mod tests {
         (schema, records, labels, formats, columns)
     }
 
-    #[test]
-    fn parse_records() {
-        let (schema, records, labels, formats, columns) = get_test_data();
-        let result = super::records_to_columns(
-            records.as_slice(),
-            &schema,
-            &convert_to_conc_enum_maps(&labels),
-            &formats,
-        );
-        assert_eq!(result, columns);
-    }
-
     pub fn convert_to_conc_enum_maps(
         enum_maps: &HashMap<usize, HashMap<String, u32>>,
     ) -> Arc<DashMap<usize, Arc<DashMap<String, u32>>>> {
@@ -190,5 +178,36 @@ mod tests {
             c_enum_maps.insert(*column, c_map)
         }
         c_enum_maps
+    }
+
+    #[test]
+    fn parse_records() {
+        let (schema, records, labels, formats, columns) = get_test_data();
+        let result = super::records_to_columns(
+            records.as_slice(),
+            &schema,
+            &convert_to_conc_enum_maps(&labels),
+            &formats,
+        );
+        assert_eq!(result, columns);
+    }
+
+    #[test]
+    fn missing_enum_map() {
+        let schema = Schema::new(vec![Field::new(DataType::Enum)]);
+        let labels = HashMap::new();
+
+        let row = vec!["1".to_string()];
+        let records = vec![ByteRecord::from(row)];
+
+        let result = super::records_to_columns(
+            records.as_slice(),
+            &schema,
+            &convert_to_conc_enum_maps(&labels),
+            &HashMap::new(),
+        );
+
+        let c = Column::from(vec![0_u32]);
+        assert_eq!(c, result[0]);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,7 +38,7 @@ pub fn records_to_columns<S: ::std::hash::BuildHasher>(
                 let val: String = v.next().unwrap().iter().map(|&c| c as char).collect();
                 let enum_value = if let Some(map) = labels.get(&fid) {
                     *map.get_or_insert(&val, (map.len() + 1).to_u32().unwrap_or(0_u32))
-                // 0 means something wrong, and enum value stars with 1.
+                // 0 means something wrong, and enum value starts with 1.
                 } else {
                     0_u32
                 };

--- a/src/table.rs
+++ b/src/table.rs
@@ -809,6 +809,37 @@ mod tests {
             DescriptionElement::DateTime(NaiveDate::from_ymd(2019, 9, 22).and_hms(6, 0, 0)),
             ds[4].get_top_n().unwrap()[0].0
         );
+        assert_eq!(
+            DescriptionElement::Enum("2".to_string()),
+            *ds[5].get_mode().unwrap()
+        );
+
+        let mut c5_map: HashMap<u32, String> = HashMap::new();
+        c5_map.insert(1, "t1".to_string());
+        c5_map.insert(2, "t2".to_string());
+        c5_map.insert(7, "t3".to_string());
+        let mut labels = HashMap::new();
+        labels.insert(5, c5_map.into_iter().map(|(k, v)| (v, k)).collect());
+        let ds = table.describe(&labels);
+
+        assert_eq!(4, ds[0].unique_count);
+        assert_eq!(
+            DescriptionElement::Text("111a qwer".to_string()),
+            *ds[1].get_mode().unwrap()
+        );
+        assert_eq!(
+            DescriptionElement::IpAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3))),
+            ds[2].get_top_n().unwrap()[1].0
+        );
+        assert_eq!(3, ds[3].unique_count);
+        assert_eq!(
+            DescriptionElement::DateTime(NaiveDate::from_ymd(2019, 9, 22).and_hms(6, 0, 0)),
+            ds[4].get_top_n().unwrap()[0].0
+        );
+        assert_eq!(
+            DescriptionElement::Enum("t2".to_string()),
+            *ds[5].get_mode().unwrap()
+        );
     }
 
     pub fn move_table_add_row(mut table: Table) {

--- a/src/table.rs
+++ b/src/table.rs
@@ -849,6 +849,7 @@ mod tests {
             ColumnOfOneRow::IpAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 100))),
             ColumnOfOneRow::Float(100.100),
             ColumnOfOneRow::DateTime(NaiveDate::from_ymd(2019, 10, 10).and_hms(10, 10, 10)),
+            ColumnOfOneRow::UInt(7),
         ];
         table
             .push_one_row(one_row, 1)

--- a/src/table.rs
+++ b/src/table.rs
@@ -13,8 +13,6 @@ use std::slice::Iter;
 
 use crate::{DataType, Schema};
 
-use log::info;
-
 const NUM_OF_FLOAT_INTERVALS: usize = 100;
 const NUM_OF_TOP_N: usize = 30;
 
@@ -96,21 +94,16 @@ impl Table {
                 let map = if let Some(enum_maps) = enum_maps {
                     if let Some(map) = enum_maps.get(&index) {
                         if !map.is_empty() {
-                            info!("TEST: ENUM describe");
                             Some(map)
                         } else {
-                            info!("TEST: (1) a map is empty.");
                             None
                         }
                     } else {
-                        info!("TEST: (2) fail in getting a map.");
                         None
                     }
                 } else {
-                    info!("TEST: (3) enum_maps is NONE.");
                     None
                 };
-                info!("TEST: describe");
                 column.describe_enum(map)
             } else {
                 column.describe()


### PR DESCRIPTION
I think it's needed to review related codes in REmake. The branch is `concurrent-enum-map`. Refer to the main part as the below. If this is Ok by you, I will request a merge of REmake.

```
fn analyze_csv<R: Read + 'static + Send>(
    input: text::Input<R>,
    rx: crossbeam_channel::Receiver<pcap::Event>,
    tx: crossbeam_channel::Sender<u64>,
    schema: Schema,
    formats: HashMap<usize, String>,
    offset: u64,
    c_enum_maps: &Arc<DashMap<usize, Arc<DashMap<String, u32>>>>,
) -> Workers<(Vec<Event<u8>>, Table)> {
    let worker_count = num_cpus::get();
    info!("Starting {} parsers", worker_count);

    let mut workers = vec![];
    for _ in 0..worker_count {
        let rx = rx.clone();
        let tx = tx.clone();
        let schema = schema.clone();
        let formats = formats.clone();
        let c_enum_maps_clone = c_enum_maps.clone();
        workers.push(thread::spawn(move || {
            let mut events = vec![];
            while let Ok(ev) = rx.recv() {
                let ack = ev.ack();
                let mut ev: Event<u8> = ev.into();
                ev.update_id(ev.id() + offset);
                events.push(ev);
                if tx.send(ack).is_err() {
                    break;
                }
            }
            let (events, columns) = parse_csv_events(events, &schema, &c_enum_maps_clone, &formats);
            let eid_map = events
                .iter()
                .enumerate()
                .map(|(i, e)| (e.id(), i))
                .collect();
            let table = Table::new(columns, eid_map);
            (events, table)
        }));
    }
    drop(tx);

    if let Err(e) = input.run() {
        error!("{}", e);
    }
    workers
}
```
 