### PR TITLE
Use concurrent enum maps for converting enum values to original ones during describing as well.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,11 +7,12 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
-#[allow(clippy::type_complexity)]
+type ConcurrentEnumMap = Arc<DashMap<usize, Arc<DashMap<String, (u32, usize)>>>>;
+
 pub fn records_to_columns<S: ::std::hash::BuildHasher>(
     values: &[ByteRecord],
     schema: &Schema,
-    labels: &Arc<DashMap<usize, Arc<DashMap<String, (u32, usize)>>>>,
+    labels: &ConcurrentEnumMap,
     formats: &HashMap<usize, String, S>,
 ) -> Vec<Column> {
     let mut records: Vec<ByteRecordIter> = values.iter().map(ByteRecord::iter).collect();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -88,9 +88,8 @@ pub fn records_to_columns<S: ::std::hash::BuildHasher>(
 mod tests {
     use super::*;
     use crate::datatypes::{DataType, Field};
-    use dashmap::DashMap;
+    use crate::table::convert_to_conc_enum_maps;
     use itertools::izip;
-    use std::sync::Arc;
 
     fn get_test_data() -> (
         Schema,
@@ -175,21 +174,6 @@ mod tests {
         let c5 = Column::from(c5_v);
         let columns: Vec<Column> = vec![c0, c1, c2, c3, c4, c5];
         (schema, records, labels, formats, columns)
-    }
-
-    pub fn convert_to_conc_enum_maps(
-        enum_maps: &HashMap<usize, HashMap<String, (u32, usize)>>,
-    ) -> Arc<DashMap<usize, Arc<DashMap<String, (u32, usize)>>>> {
-        let c_enum_maps = Arc::new(DashMap::default());
-
-        for (column, map) in enum_maps {
-            let c_map = Arc::new(DashMap::<String, (u32, usize)>::default());
-            for (data, enum_val) in map {
-                c_map.insert(data.clone(), (enum_val.0, enum_val.1));
-            }
-            c_enum_maps.insert(*column, c_map)
-        }
-        c_enum_maps
     }
 
     #[test]

--- a/src/table.rs
+++ b/src/table.rs
@@ -102,7 +102,7 @@ impl Table {
                             reverse_enum_map.insert(m.value().0, m.key().clone());
                         }
                     }
-                    reverse_enum_map.insert(0_u32, "_Small Amount_".to_string()); // unmapped ones.
+                    reverse_enum_map.insert(0_u32, "_Over One_".to_string()); // unmapped ones.
                     reverse_enum_map.insert(u32::max_value(), "_Err_".to_string()); // something wrong.
                     column.describe_enum(&reverse_enum_map)
                 } else {

--- a/src/table.rs
+++ b/src/table.rs
@@ -20,6 +20,7 @@ const NUM_OF_FLOAT_INTERVALS: usize = 100;
 const NUM_OF_TOP_N: usize = 30;
 
 type ColumnOfOneRow = DescriptionElement;
+type ConcurrentEnumMap = Arc<DashMap<usize, Arc<DashMap<String, (u32, usize)>>>>;
 
 #[derive(Debug, Default, Clone)]
 pub struct Table {
@@ -93,7 +94,7 @@ impl Table {
 
     pub fn describe(
         &self,
-        enum_maps: &HashMap<usize, HashMap<String, (u32, usize)>>,
+        enum_maps: &ConcurrentEnumMap,
     ) -> Vec<Description> {
         self.columns
             .iter()
@@ -102,8 +103,8 @@ impl Table {
                 if column.inner.is::<ColumnData<u32>>() {
                     let mut reverse_enum_map = HashMap::<u32, String>::new();
                     if let Some(map) = enum_maps.get(&index) {
-                        for (data, enum_value) in map {
-                            reverse_enum_map.insert(enum_value.0, data.clone());
+                        for m in map.iter() {
+                            reverse_enum_map.insert(m.value().0, m.key().clone());
                         }
                     }
                     reverse_enum_map.insert(0_u32, "_Small Amount_".to_string()); // unmapped ones.
@@ -821,6 +822,21 @@ mod tests {
     use std::convert::TryFrom;
     use std::net::Ipv4Addr;
 
+    pub fn convert_to_conc_enum_maps(
+        enum_maps: &HashMap<usize, HashMap<String, (u32, usize)>>,
+    ) -> Arc<DashMap<usize, Arc<DashMap<String, (u32, usize)>>>> {
+        let c_enum_maps = Arc::new(DashMap::default());
+
+        for (column, map) in enum_maps {
+            let c_map = Arc::new(DashMap::<String, (u32, usize)>::default());
+            for (data, enum_val) in map {
+                c_map.insert(data.clone(), (enum_val.0, enum_val.1));
+            }
+            c_enum_maps.insert(*column, c_map)
+        }
+        c_enum_maps
+    }
+
     #[test]
     fn description_test() {
         let c0_v: Vec<i64> = vec![1, 3, 3, 5, 2, 1, 3];
@@ -864,7 +880,7 @@ mod tests {
         let table_org = Table::try_from(c_v).expect("invalid columns");
         let table = table_org.clone();
         move_table_add_row(table_org);
-        let ds = table.describe(&HashMap::new());
+        let ds = table.describe(&convert_to_conc_enum_maps(&HashMap::new()));
 
         assert_eq!(4, ds[0].unique_count);
         assert_eq!(
@@ -891,7 +907,7 @@ mod tests {
         c5_map.insert(7, "t3".to_string());
         let mut labels = HashMap::new();
         labels.insert(5, c5_map.into_iter().map(|(k, v)| (v, (k, 0))).collect());
-        let ds = table.describe(&labels);
+        let ds = table.describe(&convert_to_conc_enum_maps(&labels));
 
         assert_eq!(4, ds[0].unique_count);
         assert_eq!(
@@ -925,7 +941,7 @@ mod tests {
         table
             .push_one_row(one_row, 1)
             .expect("Failure in adding a row");
-        let ds = table.describe(&HashMap::new());
+        let ds = table.describe(&convert_to_conc_enum_maps(&HashMap::new()));
         assert_eq!(DescriptionElement::Int(3), ds[0].get_top_n().unwrap()[0].0);
         assert_eq!(4, ds[0].get_top_n().unwrap()[0].1);
     }


### PR DESCRIPTION
Added what's required for remake to enable multithreading. The hash map for enums was used during describing and the concurrent one was used for only parsing. Instead, the concurrent one remains to be used for describing which is enabled with multithreading. To convert it to the hash map changed to be done after describing.