### PR TITLE
Make type name compatible with Apache Arrow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@ mod parse;
 mod table;
 pub(crate) mod util;
 
-pub use datatypes::{DataType, Field, Schema};
+pub use datatypes::{DataType, Field, Schema, TimeUnit};
 pub use parse::records_to_columns;
 pub use table::{Column, Description, DescriptionElement, Table};

--- a/src/table.rs
+++ b/src/table.rs
@@ -37,11 +37,10 @@ impl Table {
             .fields()
             .iter()
             .map(|field| match field.data_type() {
-                DataType::Int64 => Column::new::<i64>(),
+                DataType::Int64 | DataType::Timestamp(_) => Column::new::<i64>(),
                 DataType::Float64 => Column::new::<f64>(),
                 DataType::Utf8 => Column::new::<String>(),
                 DataType::UInt32 => Column::new::<u32>(),
-                DataType::DateTime => Column::new::<NaiveDateTime>(),
             })
             .collect();
         Self {
@@ -135,8 +134,8 @@ impl Table {
                     };
                 }
                 ColumnOfOneRow::DateTime(v) => {
-                    if let Some(c) = col.values_mut::<NaiveDateTime>() {
-                        c.push(v)
+                    if let Some(c) = col.values_mut::<i64>() {
+                        c.push(v.timestamp())
                     };
                 }
                 _ => unreachable!(), // by implementation


### PR DESCRIPTION
`DateTime` has been renamed `Timestamp`. Currently structured only supports `Second` as the time unit.