### PR TITLE
Use a raw array as a column for CSV data

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,18 +1,23 @@
-mod primitive;
-mod string;
+pub(crate) mod primitive;
+pub(crate) mod string;
 
 pub use primitive::Array as PrimitiveArray;
+pub use primitive::Builder as PrimitiveBuilder;
 pub use string::Array as StringArray;
+pub use string::ArrayIter as StringArrayIter;
 
-use crate::datatypes::DataType;
+use crate::datatypes::*;
 use crate::memory::Buffer;
+use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
 /// A dynamically-typed array.
 pub trait Array: fmt::Debug {
+    fn as_any(&self) -> &dyn Any;
     /// Returns the number of elements of this array.
     fn len(&self) -> usize;
+    fn data(&self) -> &Data;
 }
 
 /// An `Array` builder.
@@ -25,7 +30,7 @@ pub trait Builder {
 
 /// A generic representation of array data.
 #[derive(PartialEq, Debug, Clone)]
-struct Data {
+pub struct Data {
     /// The element type for this array data.
     data_type: DataType,
     /// The number of elements in this array data.
@@ -33,11 +38,16 @@ struct Data {
     buffers: Vec<Buffer>,
 }
 
+impl Data {
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}
+
 struct RawPtrBox<T> {
     inner: *const T,
 }
 
-#[allow(dead_code)]
 impl<T> RawPtrBox<T> {
     fn new(inner: *const T) -> Self {
         Self { inner }

--- a/src/array/primitive.rs
+++ b/src/array/primitive.rs
@@ -133,3 +133,15 @@ impl<T: PrimitiveType> super::Builder for Builder<T> {
         Arc::new(self.into_array())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datatypes::Int64Type;
+
+    #[test]
+    fn array_debug() {
+        let array = Builder::<Int64Type>::with_capacity(1).unwrap().into_array();
+        assert_eq!(format!("{:?}", array), "PrimitiveArray<Int64>[]");
+    }
+}

--- a/src/array/primitive.rs
+++ b/src/array/primitive.rs
@@ -1,21 +1,41 @@
 use super::{Data, RawPtrBox};
 use crate::datatypes::PrimitiveType;
 use crate::memory::{AllocationError, BufferBuilder};
+use std::any::Any;
+use std::convert::TryFrom;
 use std::fmt;
+use std::mem;
 use std::ops::Deref;
+use std::ops::Index;
 use std::slice;
 use std::sync::Arc;
 
 /// An array whose elements are of primitive types.
-#[allow(dead_code)]
 pub struct Array<T: PrimitiveType> {
     data: Arc<Data>,
     raw_values: RawPtrBox<T::Native>,
 }
 
+impl<T> Array<T>
+where
+    T: PrimitiveType,
+{
+    pub fn iter(&self) -> slice::Iter<T::Native> {
+        self.deref().iter()
+    }
+}
+
 impl<T: PrimitiveType> super::Array for Array<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn len(&self) -> usize {
         self.data.len
+    }
+
+    fn data(&self) -> &Data {
+        &self.data
     }
 }
 
@@ -34,16 +54,73 @@ impl<T: PrimitiveType> Deref for Array<T> {
     }
 }
 
+impl<T: PrimitiveType> Index<usize> for Array<T> {
+    type Output = T::Native;
+
+    /// Returns a reference to an element.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bound.
+    fn index(&self, index: usize) -> &Self::Output {
+        if index >= self.len() {
+            panic!("index out of bound");
+        }
+        unsafe { &*self.raw_values.get().add(index) }
+    }
+}
+
+impl<'a, T: PrimitiveType> IntoIterator for &'a Array<T> {
+    type Item = <PrimitiveArrayIter<'a, T> as Iterator>::Item;
+    type IntoIter = PrimitiveArrayIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+type PrimitiveArrayIter<'a, T> = slice::Iter<'a, <T as PrimitiveType>::Native>;
+
+impl<T: PrimitiveType> TryFrom<&[T::Native]> for Array<T> {
+    type Error = AllocationError;
+
+    fn try_from(slice: &[T::Native]) -> Result<Self, Self::Error> {
+        let mut builder = Builder::with_capacity(slice.len())?;
+        for s in slice {
+            builder.try_push(*s)?;
+        }
+        Ok(builder.into_array())
+    }
+}
+
 /// An array builder for primitive types.
-#[allow(dead_code)]
 pub struct Builder<T: PrimitiveType> {
     values: BufferBuilder<T>,
 }
 
-#[allow(dead_code)]
 impl<T: PrimitiveType> Builder<T> {
+    pub fn with_capacity(capacity: usize) -> Result<Self, AllocationError> {
+        Ok(Self {
+            values: BufferBuilder::<T>::with_capacity(capacity)?,
+        })
+    }
+
     pub fn try_push(&mut self, v: T::Native) -> Result<(), AllocationError> {
         self.values.try_push(v)
+    }
+
+    fn into_array(self) -> Array<T> {
+        let buffer = self.values.build();
+        let raw_values = buffer.raw_data();
+        let data = Data {
+            data_type: T::get_data_type(),
+            len: buffer.len() / mem::size_of::<T::Native>(),
+            buffers: vec![buffer],
+        };
+        Array::<T> {
+            data: Arc::new(data),
+            raw_values: RawPtrBox::new(raw_values as *const T::Native),
+        }
     }
 }
 
@@ -53,16 +130,6 @@ impl<T: PrimitiveType> super::Builder for Builder<T> {
     }
 
     fn build(self) -> Arc<dyn super::Array> {
-        let buffer = self.values.build();
-        let raw_values = buffer.raw_data();
-        let data = Data {
-            data_type: T::get_data_type(),
-            len: buffer.len(),
-            buffers: vec![buffer],
-        };
-        Arc::new(Array::<T> {
-            data: Arc::new(data),
-            raw_values: RawPtrBox::new(raw_values as *const T::Native),
-        })
+        Arc::new(self.into_array())
     }
 }

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,3 +1,3 @@
-mod reader;
+pub(crate) mod reader;
 
 pub use reader::FieldParser;

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -289,10 +289,28 @@ mod tests {
             r#"{"fields":[{"type":{"name":"utf8"}}],"metadata":{"Key":"Value"}}"#
         );
 
+        let schema = Schema::new(vec![Field::new(DataType::Int32)]);
+        assert_eq!(
+            serde_json::to_string(&schema).unwrap(),
+            r#"{"fields":[{"type":{"name":"int","bitWidth":32,"isSigned":true}}],"metadata":{}}"#
+        );
+
         let schema = Schema::new(vec![Field::new(DataType::Int64)]);
         assert_eq!(
             serde_json::to_string(&schema).unwrap(),
             r#"{"fields":[{"type":{"name":"int","bitWidth":64,"isSigned":true}}],"metadata":{}}"#
+        );
+
+        let schema = Schema::new(vec![Field::new(DataType::UInt8)]);
+        assert_eq!(
+            serde_json::to_string(&schema).unwrap(),
+            r#"{"fields":[{"type":{"name":"int","bitWidth":8,"isSigned":false}}],"metadata":{}}"#
+        );
+
+        let schema = Schema::new(vec![Field::new(DataType::UInt32)]);
+        assert_eq!(
+            serde_json::to_string(&schema).unwrap(),
+            r#"{"fields":[{"type":{"name":"int","bitWidth":32,"isSigned":false}}],"metadata":{}}"#
         );
 
         let schema = Schema::new(vec![Field::new(DataType::Float64)]);
@@ -305,12 +323,6 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&schema).unwrap(),
             r#"{"fields":[{"type":{"name":"timestamp","unit":"SECOND"}}],"metadata":{}}"#
-        );
-
-        let schema = Schema::new(vec![Field::new(DataType::UInt32)]);
-        assert_eq!(
-            serde_json::to_string(&schema).unwrap(),
-            r#"{"fields":[{"type":{"name":"int","bitWidth":32,"isSigned":false}}],"metadata":{}}"#
         );
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -31,6 +31,7 @@ impl Buffer {
     ///
     /// The size of the slice should not overflow when aligned on a
     /// 64-byte boundary, i.e., `vec.len() <= usize::max_value() - 63`.
+    #[allow(dead_code)]
     pub(crate) unsafe fn from_small_slice(vec: &[u8]) -> Self {
         debug_assert!(vec.len() <= usize::max_value() - 63);
         let capacity = bit_util::round_upto_multiple_of_64(vec.len());
@@ -94,6 +95,7 @@ impl BufferData {
     /// of bytes allocated for the memory at `ptr`. If `owned` is `true`, the
     /// memory at `ptr` must be deallocated by this `BufferData`'s
     /// implementation only.
+    #[allow(dead_code)]
     unsafe fn new(ptr: *const u8, len: usize, owned: bool) -> Self {
         debug_assert!(!ptr.is_null());
         Self { ptr, len, owned }
@@ -193,6 +195,7 @@ impl BufferMut {
     }
 
     /// Returns the number of bytes written in this buffer.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.len
     }
@@ -317,14 +320,12 @@ pub enum AllocationError {
 }
 
 /// Buffer builder.
-#[allow(dead_code)]
 pub struct BufferBuilder<T: PrimitiveType> {
     buffer: BufferMut,
     len: usize,
     _marker: PhantomData<T>,
 }
 
-#[allow(dead_code)]
 impl<T> BufferBuilder<T>
 where
     [T::Native]: RawBytes,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,8 @@
-use crate::csv::FieldParser;
+use crate::array::{string, Builder, PrimitiveBuilder};
+use crate::csv::{reader::*, FieldParser};
+use crate::datatypes::*;
 use crate::Column;
-use csv::{ByteRecord, ByteRecordIter};
+use csv::ByteRecord;
 use dashmap::DashMap;
 use num_traits::ToPrimitive;
 use std::sync::Arc;
@@ -11,45 +13,32 @@ pub fn records_to_columns(
     values: &[ByteRecord],
     parsers: &[FieldParser],
     labels: &ConcurrentEnumMaps,
-) -> Vec<Column> {
-    let mut records: Vec<ByteRecordIter> = values.iter().map(ByteRecord::iter).collect();
-    parsers
-        .iter()
-        .enumerate()
-        .map(|(fid, parser)| match parser {
+) -> Result<Vec<Column>, string::Error> {
+    let mut batch = Vec::with_capacity(parsers.len());
+    for (i, parser) in parsers.iter().enumerate() {
+        let col = match parser {
             FieldParser::Int64(parse) | FieldParser::Timestamp(parse) => {
-                Column::with_data(records.iter_mut().fold(vec![], |mut col, v| {
-                    let v = v.next().unwrap();
-                    col.push(parse(v).unwrap_or_default());
-                    col
-                }))
+                build_primitive_array::<Int64Type, Int64Parser>(values, i, parse)?
             }
             FieldParser::Float64(parse) => {
-                Column::with_data(records.iter_mut().fold(vec![], |mut col, v| {
-                    let v = v.next().unwrap();
-                    col.push(parse(v).unwrap_or_default());
-                    col
-                }))
+                build_primitive_array::<Float64Type, Float64Parser>(values, i, parse)?
             }
             FieldParser::Utf8 => {
-                Column::with_data(records.iter_mut().fold(vec![], |mut col, v| {
-                    let val: String = v.next().unwrap().iter().map(|&c| c as char).collect();
-                    col.push(val);
-                    col
-                }))
+                let mut builder = string::Builder::with_capacity(values.len())?;
+                for row in values {
+                    builder.try_push(std::str::from_utf8(row.get(i).unwrap_or_default())?)?;
+                }
+                builder.build()
             }
             FieldParser::UInt32(parse) => {
-                Column::with_data(records.iter_mut().fold(vec![], |mut col, v| {
-                    let v = v.next().unwrap();
-                    col.push(parse(v).unwrap_or_default());
-                    col
-                }))
+                build_primitive_array::<UInt32Type, UInt32Parser>(values, i, parse)?
             }
             FieldParser::Dict => {
-                Column::with_data(records.iter_mut().fold(vec![], |mut col, v| {
-                    let val: String = v.next().unwrap().iter().map(|&c| c as char).collect();
-                    col.push(labels.get(&fid).map_or_else(u32::max_value, |map| {
-                        map.entry(val)
+                let mut builder = PrimitiveBuilder::<UInt32Type>::with_capacity(values.len())?;
+                for r in values {
+                    let key = std::str::from_utf8(r.get(i).unwrap_or_default())?;
+                    let value = labels.get(&i).map_or_else(u32::max_value, |map| {
+                        map.entry(key.to_string())
                             .and_modify(|v| *v = (v.0, v.1 + 1))
                             .or_insert_with(|| {
                                 (
@@ -58,21 +47,26 @@ pub fn records_to_columns(
                                 )
                             })
                             .0
-                    }));
-                    // u32::max_value means something wrong, and 0 means unmapped. And, enum value starts with 1.
-                    col
-                }))
+                        // u32::max_value means something wrong, and 0 means unmapped. And, enum value starts with 1.
+                    });
+                    builder.try_push(value)?;
+                }
+                builder.build()
             }
-        })
-        .collect()
+        };
+        batch.push(col.into());
+    }
+    Ok(batch)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::array::{string, Array};
     use chrono::{NaiveDate, NaiveDateTime};
     use itertools::izip;
     use std::collections::HashMap;
+    use std::convert::TryFrom;
     use std::net::Ipv4Addr;
 
     pub fn convert_to_conc_enum_maps(
@@ -91,21 +85,12 @@ mod tests {
     }
 
     fn get_test_data() -> (
-        [FieldParser; 6],
         Vec<ByteRecord>,
         HashMap<usize, HashMap<String, (u32, usize)>>,
         Vec<Column>,
     ) {
         let c0_v: Vec<i64> = vec![1, 3, 3, 5, 2, 1, 3];
-        let c1_v: Vec<String> = vec![
-            "111a qwer".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-            "d".to_string(),
-            "b".to_string(),
-            "111a qwer".to_string(),
-            "111a qwer".to_string(),
-        ];
+        let c1_v: Vec<_> = vec!["111a qwer", "b", "c", "d", "b", "111a qwer", "111a qwer"];
         let c2_v: Vec<Ipv4Addr> = vec![
             Ipv4Addr::new(127, 0, 0, 1),
             Ipv4Addr::new(127, 0, 0, 2),
@@ -144,13 +129,41 @@ mod tests {
         ) {
             let mut row: Vec<String> = vec![];
             row.push(c0.to_string());
-            row.push(c1.clone());
+            row.push(c1.to_string());
             row.push(c2.to_string());
             row.push(c3.to_string());
             row.push(c4.format(fmt).to_string());
             row.push(c5_map.get(c5).unwrap().to_string());
             records.push(ByteRecord::from(row));
         }
+        let mut labels = HashMap::new();
+        labels.insert(5, c5_map.into_iter().map(|(k, v)| (v, (k, 0))).collect());
+
+        let c0 = Column::try_from_slice::<Int64Type>(&c0_v).unwrap();
+        let c1_a: Arc<dyn Array> = Arc::new(string::Array::try_from(c1_v.as_slice()).unwrap());
+        let c1 = Column::from(c1_a);
+        let c2 = Column::try_from_slice::<UInt32Type>(
+            c2_v.iter()
+                .map(|&v| -> u32 { v.into() })
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .unwrap();
+        let c3 = Column::try_from_slice::<Float64Type>(&c3_v).unwrap();
+        let c4 = Column::try_from_slice::<Int64Type>(
+            c4_v.iter()
+                .map(|v| v.timestamp())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .unwrap();
+        let c5 = Column::try_from_slice::<UInt32Type>(&c5_v).unwrap();
+        let columns: Vec<Column> = vec![c0, c1, c2, c3, c4, c5];
+        (records, labels, columns)
+    }
+
+    #[test]
+    fn parse_records() {
         let parsers = [
             FieldParser::int64(),
             FieldParser::Utf8,
@@ -161,35 +174,17 @@ mod tests {
             FieldParser::float64(),
             FieldParser::timestamp_with_parser(move |v| {
                 let val: String = v.iter().map(|&c| c as char).collect();
-                Ok(NaiveDateTime::parse_from_str(&val, fmt)?.timestamp())
+                Ok(NaiveDateTime::parse_from_str(&val, "%Y-%m-%d %H:%M:%S")?.timestamp())
             }),
             FieldParser::Dict,
         ];
-        let mut labels = HashMap::new();
-        labels.insert(5, c5_map.into_iter().map(|(k, v)| (v, (k, 0))).collect());
-
-        let c0 = Column::from(c0_v);
-        let c1 = Column::from(c1_v);
-        let c2 = Column::from(
-            c2_v.iter()
-                .map(|&v| -> u32 { v.into() })
-                .collect::<Vec<_>>(),
-        );
-        let c3 = Column::from(c3_v);
-        let c4 = Column::from(c4_v.iter().map(|v| v.timestamp()).collect::<Vec<_>>());
-        let c5 = Column::from(c5_v);
-        let columns: Vec<Column> = vec![c0, c1, c2, c3, c4, c5];
-        (parsers, records, labels, columns)
-    }
-
-    #[test]
-    fn parse_records() {
-        let (parsers, records, labels, columns) = get_test_data();
+        let (records, labels, columns) = get_test_data();
         let result = super::records_to_columns(
             records.as_slice(),
             &parsers,
             &convert_to_conc_enum_maps(&labels),
-        );
+        )
+        .unwrap();
         assert_eq!(result, columns);
     }
 
@@ -205,9 +200,10 @@ mod tests {
             records.as_slice(),
             &parsers,
             &convert_to_conc_enum_maps(&labels),
-        );
+        )
+        .unwrap();
 
-        let c = Column::from(vec![u32::max_value()]);
+        let c = Column::try_from_slice::<UInt32Type>(&[u32::max_value()][0..1]).unwrap();
         assert_eq!(c, result[0]);
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -911,6 +911,19 @@ mod tests {
     use std::net::Ipv4Addr;
 
     #[test]
+    fn table_new() {
+        let table = Table::new(Vec::new(), HashMap::new());
+        assert_eq!(table.num_columns(), 0);
+        assert_eq!(table.num_rows(), 0);
+    }
+
+    #[test]
+    fn table_try_from() {
+        let table = Table::try_from(Vec::new());
+        assert!(table.is_ok());
+    }
+
+    #[test]
     fn column_new() {
         let column = Column::new::<UInt32ArrayType>();
         assert_eq!(column.len(), 0);

--- a/src/util/bit_util.rs
+++ b/src/util/bit_util.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 static BIT_MASK: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
 
 /// Returns the nearest number that is `>=` than `num` and is a multiple of 64
@@ -12,6 +13,7 @@ pub fn round_upto_multiple_of_64(num: usize) -> usize {
 ///
 /// Note this doesn't do any bound checking, for performance reason. The caller is
 /// responsible to guarantee that `i` is within bounds.
+#[allow(dead_code)]
 #[inline]
 pub unsafe fn get_bit_raw(data: *const u8, i: usize) -> bool {
     (*data.add(i >> 3) & BIT_MASK[i & 7]) != 0


### PR DESCRIPTION
This reduces `match` statements for CSV column types, and improves memory locality of a string array.