### PR TITLE
downgrade dashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }
 csv = "1"
-dashmap = "2"
+dashmap = "1"
 itertools = "0.8"
 num-traits = "0.2"
 statistical = "1"


### PR DESCRIPTION
Dashmap 2.x seems to have a problem in both functions, `or_insert` and `or_insert_with` of `Entry` which was introduced in this version .  As required is to get the length of an enum map atomically while insertion, one of the two should work properly. But, the process halts unless invariable values are given to the functions. Therefore, we should use the previous version until this would be fixed.