### PR TITLE
Avoid a panic when computing top N elements in an empty set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Avoid a panic when computing top N elements in an empty set.
+
 ## [0.5.0] - 2020-06-21
 
 ### Changed

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -271,7 +271,7 @@ macro_rules! top_n {
                 count: *y,
             });
         }
-        $d.mode = Some(top_n[0].value.clone());
+        $d.mode = top_n.first().map(|v| v.value.clone());
         $d.top_n = Some(top_n);
     };
 }


### PR DESCRIPTION
The `top_n` macro panics if the given data is empty.