### PR TITLE
change timestamp to timestamp_nanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
 - Updated arrow to verion 32.
+- Use timestamp with nano seconds instead of timestamp with only seconds value.
 
 ## [0.9.0] - 2022-10-17
 

--- a/src/csv/reader.rs
+++ b/src/csv/reader.rs
@@ -252,7 +252,7 @@ where
 fn parse_timestamp(v: &[u8]) -> Result<i64, ParseError> {
     Ok(
         chrono::NaiveDateTime::parse_from_str(str::from_utf8(v)?, "%Y-%m-%dT%H:%M:%S%.f%:z")?
-            .timestamp(),
+            .timestamp_nanos(),
     )
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -527,6 +527,7 @@ pub(crate) fn convert_time_intervals(
     rows: &[usize],
     time_interval: u32,
 ) -> Vec<NaiveDateTime> {
+    const A_BILLION: i64 = 1_000_000_000;
     let time_interval = if time_interval > MAX_TIME_INTERVAL {
         MAX_TIME_INTERVAL
     // Users want to see time series of the same order intervals within MAX_TIME_INTERVAL which is in date units.
@@ -546,9 +547,9 @@ pub(crate) fn convert_time_intervals(
         .unwrap()
         .map(|v| {
             // The first interval of each day should start with 00:00:00.
-            let mut ts = v / (24 * 60 * 60) * (24 * 60 * 60);
+            let mut ts = v / ((24 * 60 * 60) * (24 * 60 * 60) * A_BILLION);
             ts += (v - ts) / time_interval * time_interval;
-            NaiveDateTime::from_timestamp_opt(ts, 0).unwrap()
+            NaiveDateTime::from_timestamp_opt(ts, 0).unwrap_or_default()
         })
         .collect::<Vec<_>>()
 }


### PR DESCRIPTION
Current timestamp parser drops the nano second value when it read datetime field from raw event like `1562050571.390240`.

When REconverge make pcap extraction requests message to Giganto for the labeled events, it requires exact timestamp value including nano second.

Changes:
* `parse_timestamp()` function is changed to return `timestamp_nanos()` result instead of `timestamp()`
