### PR TITLE
fix the datetime conversion failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: cargo test --verbose
     - name: Generate coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-      run: cargo tarpaulin --out Xml
+      run: cargo tarpaulin --out xml
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix the bug that the converted datetime returns always `1970-01-01T00:00:00`.
+
 ## [0.14.0] - 2023-07-17
 
 ### Changed
@@ -173,6 +179,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   column-oriented form.
 - Interface to read CSV data into `Table`.
 
+[Unreleased]: https://github.com/petabi/structured/compare/0.14.0...main
 [0.14.0]: https://github.com/petabi/structured/compare/0.13.0...0.14.0
 [0.13.0]: https://github.com/petabi/structured/compare/0.12.0...0.13.0
 [0.12.0]: https://github.com/petabi/structured/compare/0.11.0...0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "structured"
-version = "0.14.0"
+version = "0.14.1"
 authors = [
   "Min Kim <msk@dolbo.net>",
   "Min Shao <min.shao1988@gmail.com>",
   "Sehkone Kim <sehkone@petabi.com>",
 ]
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.70"
 description = "Data structures to handle large, structured data."
 homepage = "https://github.com/petabi/structured"
 repository = "https://github.com/petabi/structured"
@@ -18,16 +18,16 @@ exclude = ["./github"]
 codecov = { repository = "petabi/structured", service = "github" }
 
 [dependencies]
-arrow = "43"
-chrono = { version = "^0.4.9", default-features = false, features = ["serde"] }
+arrow = "47"
+chrono = { version = "0.4.31", default-features = false, features = ["serde"] }
 csv-core = "0.1"
 itertools = "0.11"
 num-traits = "0.2"
-ordered-float = { version = "3.4.0", default-features = false }
+ordered-float = { version = "4.1.0", default-features = false }
 percent-encoding = "2.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "^1.0.13", features = ["preserve_order"] }
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 statistical = "1"
 strum = "0.25"
 strum_macros = "0.25"

--- a/src/csv/reader.rs
+++ b/src/csv/reader.rs
@@ -261,7 +261,8 @@ where
 fn parse_timestamp(v: &[u8]) -> Result<i64, ParseError> {
     Ok(
         chrono::NaiveDateTime::parse_from_str(str::from_utf8(v)?, "%Y-%m-%dT%H:%M:%S%.f%:z")?
-            .timestamp_nanos(),
+            .timestamp_nanos_opt()
+            .unwrap_or_default(),
     )
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -138,6 +138,9 @@ where
         &self.schema
     }
 
+    /// # Panics
+    ///
+    /// Panics if time intervals or number of top n is not defined.
     #[must_use]
     pub fn statistics(
         &self,
@@ -208,6 +211,9 @@ where
     }
 
     // count means including only positive values. Implement other functions like sum_group_by, mean_group_by, etc. later.
+    /// # Panics
+    ///
+    /// Panics if columns are not defined.
     #[must_use]
     pub fn count_group_by(
         &self,
@@ -346,12 +352,10 @@ impl Column {
             Ok(i) => (i, 0),
             Err(i) => (i - 1, index - self.cumlen[i - 1]),
         };
-        let typed_arr = if let Some(arr) = self.arrays[array_index]
+        let Some(typed_arr) = self.arrays[array_index]
             .as_any()
             .downcast_ref::<PrimitiveArray<T>>()
-        {
-            arr
-        } else {
+        else {
             return Err(TypeError());
         };
         Ok(Some(typed_arr.value(inner_index)))
@@ -370,12 +374,10 @@ impl Column {
             Ok(i) => (i, 0),
             Err(i) => (i - 1, index - self.cumlen[i - 1]),
         };
-        let typed_arr = if let Some(arr) = self.arrays[array_index]
+        let Some(typed_arr) = self.arrays[array_index]
             .as_any()
             .downcast_ref::<BinaryArray>()
-        {
-            arr
-        } else {
+        else {
             return Err(TypeError());
         };
         Ok(Some(typed_arr.value(inner_index)))
@@ -394,12 +396,10 @@ impl Column {
             Ok(i) => (i, 0),
             Err(i) => (i - 1, index - self.cumlen[i - 1]),
         };
-        let typed_arr = if let Some(arr) = self.arrays[array_index]
+        let Some(typed_arr) = self.arrays[array_index]
             .as_any()
             .downcast_ref::<StringArray>()
-        {
-            arr
-        } else {
+        else {
             return Err(TypeError());
         };
         Ok(Some(typed_arr.value(inner_index)))
@@ -430,9 +430,7 @@ impl Column {
     {
         let mut arrays: Vec<&T> = Vec::with_capacity(self.arrays.len());
         for arr in &self.arrays {
-            let typed_arr = if let Some(arr) = arr.as_any().downcast_ref::<T>() {
-                arr
-            } else {
+            let Some(typed_arr) = arr.as_any().downcast_ref::<T>() else {
                 return Err(TypeError());
             };
             arrays.push(typed_arr);
@@ -739,42 +737,50 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(0, 0, 10)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 13)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 15)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 22)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 22)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 31)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 33)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2020, 1, 1)
                 .unwrap()
                 .and_hms_opt(0, 1, 1)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
         ];
         let c1_v: Vec<i64> = vec![1, 32, 3, 5, 2, 1, 3, 24];
         let c2_v: Vec<i64> = vec![2, 33, 4, 6, 3, 2, 4, 25];
@@ -830,37 +836,44 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(6, 10, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 22)
                 .unwrap()
                 .and_hms_opt(6, 15, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 21)
                 .unwrap()
                 .and_hms_opt(20, 10, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 21)
                 .unwrap()
                 .and_hms_opt(20, 10, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 22)
                 .unwrap()
                 .and_hms_opt(6, 45, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 21)
                 .unwrap()
                 .and_hms_opt(8, 10, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             NaiveDate::from_ymd_opt(2019, 9, 22)
                 .unwrap()
                 .and_hms_opt(9, 10, 11)
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
         ];
         let tester = vec!["t1".to_string(), "t2".to_string(), "t3".to_string()];
         let sid = tester.iter().map(|s| hash(s)).collect::<Vec<_>>();


### PR DESCRIPTION
* Fix the bug that the datetime conversion returns always `1970-01-01T00:00:00`.
* Fix clippy warnings
* Fix compiler version in `Cargo.toml` to synchorinize with the version in `ci.yml`
* Bump crates version to latest