### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.0] - 2024-12-10
 
 ### Changed
 
@@ -185,7 +185,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   column-oriented form.
 - Interface to read CSV data into `Table`.
 
-[Unreleased]: https://github.com/petabi/structured/compare/0.14.1...main
+[0.15.0]: https://github.com/petabi/structured/compare/0.14.1...0.15.0
 [0.14.1]: https://github.com/petabi/structured/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/petabi/structured/compare/0.13.0...0.14.0
 [0.13.0]: https://github.com/petabi/structured/compare/0.12.0...0.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structured"
-version = "0.14.1"
+version = "0.15.0"
 authors = [
   "Min Kim <msk@dolbo.net>",
   "Min Shao <min.shao1988@gmail.com>",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Version 0.15.0 released on December 10, 2024.
- **Changed**
	- Updated the `arrow` library to version 53.
- **Documentation**
	- Changelog updated to reflect the new version and historical entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->